### PR TITLE
KHP3-5544- Generate patient appointment messages from Ba…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -125,6 +125,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.bahmni.module</groupId>
+			<artifactId>appointments-api</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>kenyacore-test</artifactId>
 			<scope>test</scope>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -23,6 +23,7 @@
         <require_module version="2.1">org.openmrs.module.webservices.rest</require_module>
         <require_module version="${kenyacoreVersion}">org.openmrs.module.kenyacore</require_module>
         <require_module version="${fhir2Version}">org.openmrs.module.fhir2</require_module>
+        <require_module>org.bahmni.module.appointments</require_module>
     </require_modules>
     <!-- Adds link to admin page -->
     <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <apacheHttpClientVersion>4.5.10</apacheHttpClientVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fhir-core.version>5.4.0</fhir-core.version>
-        <bahmniAppointmentsVersion>1.5.0-SNAPSHOT</bahmniAppointmentsVersion>
+        <bahmniAppointmentsVersion>2.0.0-SNAPSHOT</bahmniAppointmentsVersion>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <apacheHttpClientVersion>4.5.10</apacheHttpClientVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fhir-core.version>5.4.0</fhir-core.version>
+        <bahmniAppointmentsVersion>1.5.0-SNAPSHOT</bahmniAppointmentsVersion>
     </properties>
 
     <dependencyManagement>
@@ -314,6 +315,12 @@
                 <scope>provided</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.bahmni.module</groupId>
+                <artifactId>appointments-api</artifactId>
+                <version>${bahmniAppointmentsVersion}</version>
+                <scope>provided</scope>
+            </dependency>
             <!-- End OpenMRS core -->
             <!-- https://mvnrepository.com/artifact/org.json/json -->
             <dependency>


### PR DESCRIPTION
This PR refactors the logic for generating messages for Ushauri appointment messages. 
It does the following:
1. Gets new/changed appointments (incrementally) from Bahmni appointment backend
2. Generates a list of patientIDs from 1 above. We use the IDs to fetch the latest consent for reminders from the green card
3. Only appointments with 'Scheduled' status are considered. Others are ignored.
4. Refines reminders for PrEP appointments 